### PR TITLE
Update annotations/net.app.core.directory.twitter.md

### DIFF
--- a/annotations/net.app.core.directory.twitter.md
+++ b/annotations/net.app.core.directory.twitter.md
@@ -5,10 +5,14 @@
 > ### net.app.core.directory.twitter
 
 <!-- provide a description of what your annotation represents -->
-A pointer to the user's Twitter account.
+A pointer to the user's Twitter account. 
+
+You can use either the username (which can be changed and so might become inaccurate over time) or the user id (which can't), or both. 
+
+If using both, then they ought to match (at least at the time of posting). However clients may not wish to rely upon this, and opt to look up the Twitter username from the id themselves.
 
 <!-- provide at least one example of what your annotation might look like in the wild -->
-## Example
+## Examples
 
 ~~~ js
 {
@@ -19,12 +23,22 @@ A pointer to the user's Twitter account.
 }
 ~~~
 
+~~~ js
+{
+    "type": "net.app.core.directory.twitter",
+    "value": {
+        "user_id": "123456789",
+    }
+}
+~~~
+
 <!-- provide a complete description of the fields in the "value" object for your annotation -->
 ## Fields
 
 | Field    | Required? | Type   | Description                                       |
 | -----    | --------- | ----   | -----------                                       |
-| username | Required  | string | A Twitter username representing the App.net User. |
+| username | Optional  | string | A Twitter username representing the App.net User. |
+| user_id  | Optional  | string | A Twitter user id representing the App.net User.  |
 
 <!-- provide a way to contact you -->
 ## Maintainers


### PR DESCRIPTION
Twitter user ids should be supported as well as usernames, as people change their usernames more often than you'd think, and it's trivial to look up an account's current username given its id.
