### PR TITLE
Typing Presence annotation

### DIFF
--- a/annotations/com.mustacheware.amy.pm.typing.md
+++ b/annotations/com.mustacheware.amy.pm.typing.md
@@ -1,0 +1,54 @@
+<!-- give your annotation a title -->
+# Typing Presence 
+
+<!-- specify the "type" for your annotation -->
+> ### com.mustacheware.amy.pm.typing
+
+<!-- provide a description of what your annotation represents -->
+The Typing Presence annotation specifies when a user has started or stopped typing something in a private messaging session.
+
+Accepting or emitting this annotation is entirely optional.
+
+This annotation must be supplied as a machine-only post.
+
+<!-- provide at least one example of what your annotation might look like in the wild -->
+## Example - Start Typing
+
+~~~ js
+{
+    "type": "com.mustacheware.amy.pm.typing",
+    "value": {
+        "is_typing": true 
+    }
+}
+~~~
+
+## Example - Stop Typing
+
+~~~ js
+{
+    "type": "com.mustacheware.amy.pm.typing",
+    "value": {
+        "is_typing": false 
+    }
+}
+~~~
+
+<!-- provide a complete description of the fields in the "value" object for your annotation -->
+## Fields
+
+| Field     | Required? | Type    | Description                                                                                       |
+| -----     | --------- | ----    | -----------                                                                                       |
+| is_typing | Required  | boolean | True if the user has started typing, false if the user stops typing (e.g. clears the text field). |
+
+<!-- provide a way to contact you -->
+## Maintainers
+* [Steve Streza](http://stevestreza.com) ([@SteveStreza](https://alpha.app.net/SteveStreza), [steve@stevestreza.com](mailto:steve@stevestreza.com))
+
+<!-- provide references to compatible apps / service -->
+## Used by
+* Forthcoming App
+
+<!-- provide references to related annotations -->
+## Related annotations
+* N/A

--- a/annotations/com.mustacheware.amy.pm.typing.md
+++ b/annotations/com.mustacheware.amy.pm.typing.md
@@ -5,7 +5,7 @@
 > ### com.mustacheware.amy.pm.typing
 
 <!-- provide a description of what your annotation represents -->
-The Typing Presence annotation specifies when a user has started or stopped typing something in a private messaging session.
+The Typing Presence annotation specifies when the posting user has started or stopped typing something in a private messaging session.
 
 Accepting or emitting this annotation is entirely optional.
 

--- a/annotations/net.app.ohai.displaydate.md
+++ b/annotations/net.app.ohai.displaydate.md
@@ -1,0 +1,38 @@
+<!-- give your annotation a title -->
+# Display Date
+
+<!-- specify the "type" for your annotation -->
+> ### net.app.ohai.displaydate
+
+<!-- provide a description of what your annotation represents -->
+The display date annotation is meant to specify a custom date to associate with a message. It should only be used when a person intended to create the post with a different date. For example, if your app supports posting offline, an offline post could contain this annotation for when the post was created locally. When it gets posted to the network, it will have a different creation date, but the annotation can accurately represent when the user created the post or message.
+
+<!-- provide at least one example of what your annotation might look like in the wild -->
+## Example
+
+~~~ js
+{
+    "type": "net.app.ohai.displaydate",
+    "value": {
+        "date": "2013-06-02T18:51:34Z",
+    }
+}
+~~~
+
+<!-- provide a complete description of the fields in the "value" object for your annotation -->
+## Fields
+
+| Field         | Required? | Type   | Description                                                     |
+| -----         | --------- | ----   | -----------                                                     |
+| date          | Required  | string | The time at which the message was created in ISO 8601 format.   |
+
+<!-- provide a way to contact you -->
+## Maintainers
+* [Steve Streza](http://stevestreza.com) ([@SteveStreza](https://alpha.app.net/SteveStreza))
+
+<!-- provide references to compatible apps / service -->
+## Used by 
+* [Ohai](http://ohaiapp.net)
+
+<!-- provide references to related annotations -->
+## Related annotations

--- a/annotations/net.app.ohai.location.md
+++ b/annotations/net.app.ohai.location.md
@@ -1,0 +1,65 @@
+<!-- give your annotation a title -->
+# Custom Checkin
+
+<!-- specify the "type" for your annotation -->
+> ### net.app.ohai.location
+
+<!-- provide a description of what your annotation represents -->
+Indicates that a user has "checked in" to a custom place as part of a resource. This is meant to be identical to a normal [checkin](https://github.com/appdotnet/object-metadata/blob/master/annotations/net.app.core.checkin.md), but used when a Place does not exist for a given location. Every field is identical to the checkin annotation, except `factual_id` is instead just `id`. All fields are optional, except for the `id` field, which must be some unique identifier (a UUID is recommended).
+
+<!-- provide at least one example of what your annotation might look like in the wild -->
+## Example
+
+### Provided to App.net
+
+~~~ js
+{
+    "type": "net.app.ohai.location", 
+    "value": {
+        "address": "20 Yerba Buena Lane", 
+        "country_code": "US", 
+        "id": "B572B5D8-5D5D-43F7-96D5-D9EB6D5D188E", 
+        "latitude": 37.78612, 
+        "locality": "San Francisco", 
+        "longitude": -122.404631, 
+        "name": "Press Club", 
+        "postcode": "94103", 
+        "region": "California"
+    }
+}
+~~~
+
+<!-- provide a complete description of the fields in the "value" object for your annotation -->
+## Fields
+
+| Field | Required? | Type | Description |
+| ----- | --------- | ---- | ----------- |
+| `id` | Required | string | Primary identifier for a place. If you check in to a place multiple times, each place should have the same `id`. Recommended to be a UUID. |
+| `name` | Optional | string | Human-friendly name. |
+| `address` | Optional | string | Street address. |
+| `address_extended` | Optional | string | Apartment or Suite number in street address. |
+| `locality` | Optional | string | City or town. |
+| `region` | Optional | string | State, region, province etc. |
+| `admin_region` | Optional | string | Additional sub-division (e.g. Wales). |
+| `post_town` | Optional | string | Town used in postal addressing. |
+| `po_box` | Optional | string | PO Box. |
+| `postcode` | Optional | string | Postcode / zipcode. |
+| `country_code` | Optional | string | A two-letter country code in ISO 3166-1 alpha-2 format. |
+| `latitude` | Optional | decimal | Latitude in decimal degrees. |
+| `longitude` | Optional | decimal | Longitude in decimal degrees. |
+| `is_open` | Optional | boolean | Whether the establishment is still "in business" and/or open to the public and does not refer to business hours or whether it may be serving customers at any particular moment in time. |
+| `telephone` | Optional | string | Telephone number in local formatting. |
+
+
+<!-- provide a way to contact you -->
+## Maintainers
+* [Steve Streza](http://stevestreza.com) ([@SteveStreza](https://alpha.app.net/SteveStreza))
+
+<!-- provide references to compatible apps / service -->
+## Used by 
+* [Ohai](http://ohaiapp.net)
+
+<!-- provide references to related annotations -->
+## Related annotations
+* [+net.app.core.place](https://github.com/appdotnet/object-metadata/blob/master/annotation-replacement-values/+net.app.core.place.md)
+* [net.app.core.checkin](https://github.com/appdotnet/object-metadata/blob/master/annotation/net.app.core.checkin.md)

--- a/channel-types/net.app.ohai.journal.md
+++ b/channel-types/net.app.ohai.journal.md
@@ -1,0 +1,39 @@
+<!-- give your channel type a title -->
+# Journal
+
+<!-- specify the channel type -->
+> ### net.app.ohai.journal
+
+<!-- provide a description for this channel type's behavior -->
+This channel type represents a user's personal journal containing messages referred to as "entries". Entries may 
+
+### Finding the Journal
+
+A user may only have one journal channel. However, it is possible for them to be subscribed to more than one. A user's journal may be found by getting the user's subscribed channels of type `net.app.ohai.journal`. If they have more than one, filter to channels owned by the authenticated user that have an immutable writer ACL containing only the authenticated user and a mutable reader ACL. If there is still more than one, find the channel with the oldest channel ID.
+
+### Creating Journal Entries
+
+Any application can post entries into a user's journal. If you find a journal using the above algorithm, developers should show UI to allow the user to post entries into a journal. For example, a photo-sharing app that allows posting photos to App.net and Twitter could also add a button to share that photo to a journal. If you do not detect a journal, do not create a new journal channel, and do not show the user this option, as it may be confusing.
+
+It should be noted that any application supporting any kind of data can be published into a journal. For example, an application which allows users to "check in" to a movie can publish a custom annotation into the journal, even if it is not supported by current applications. The important thing to consider is that a user must intend to publish into their journal; manual user action must be taken to publish, or the user must have manually enabled an automatic publish process if your app chooses to support it. Users should not have their journals cluttered by apps without intent. **Apps may be filtered out by journal client apps if they publish without user intent.** This is a very important rule, so please respect it.
+
+### Showing Journal Entries
+
+When the user logs in, look to see if they already have a journal using the above algorithm. If they do have one, download the entire set of all messages within the channel and store them locally. If they do not have a journal channel, create one. A new journal must have the following properties:
+
+- the type `net.app.ohai.journal`
+- an immutable writer ACL that only contains the current user
+- a mutable reader ACL that contains nobody
+
+Any kind of set of annotations can be contained in posts, so very strict validation of all messages must be used. Clients should not crash or otherwise fail if a malformed annotation is included. Clients should only show entries that conform to certain requirements (for example, Ohai 1.0 only shows entries with locations attached, optionally with photos). Entries may optionally contain text, so API requests for entries should include machine-only messages. Entries are almost always annotated, so annotations should be requested as well.
+
+<!-- provide a way to contact you -->
+## Maintainers
+* [Steve Streza](http://stevestreza.com) ([@SteveStreza](https://alpha.app.net/SteveStreza))
+
+<!-- provide references to compatible apps / service -->
+## Used by 
+* [Ohai](http://ohaiapp.net)
+
+<!-- provide references to related entries -->
+## Related entries


### PR DESCRIPTION
Many private messaging apps (e.g. AIM, iMessage) supply the ability for clients to pass data about whether either user in a chat is currently typing. The client can either update the UI or do nothing. This annotation specifies if the user has started or stopped typing in a machine-only post to a channel.
